### PR TITLE
Fix server alias resolution for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx server/index.ts",
     "build": "next build --turbopack && tsc -p tsconfig.server.json",
-    "start": "NODE_ENV=production node dist/server.js",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "lint": "eslint --ext .ts,.tsx .",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,8 @@
+import "./registerPaths";
 import express, { Request, Response } from "express";
 import next from "next";
-import { handleRoundTrip } from "@/app/api/routes/roundtrip/handler";
-import { handlePointToPoint } from "@/app/api/routes/point2point/handler";
+import { handleRoundTrip } from "../app/api/routes/roundtrip/handler";
+import { handlePointToPoint } from "../app/api/routes/point2point/handler";
 
 const port = Number.parseInt(process.env.PORT ?? "3000", 10);
 const dev = process.env.NODE_ENV !== "production";

--- a/server/registerPaths.ts
+++ b/server/registerPaths.ts
@@ -1,0 +1,31 @@
+import Module from "node:module";
+import path from "node:path";
+
+type ModuleWithResolve = typeof Module & {
+  _resolveFilename: (
+    request: string,
+    parent: NodeModule | undefined,
+    isMain: boolean,
+    options?: unknown,
+  ) => string;
+};
+
+const moduleWithResolve = Module as ModuleWithResolve;
+
+const originalResolveFilename = moduleWithResolve._resolveFilename;
+
+moduleWithResolve._resolveFilename = function resolveWithAlias(
+  request: string,
+  parent: NodeModule | undefined,
+  isMain: boolean,
+  options?: ModuleResolveFilenameOptions,
+) {
+  if (request.startsWith("@/")) {
+    const resolved = path.join(__dirname, "..", request.slice(2));
+    return originalResolveFilename.call(this, resolved, parent, isMain, options);
+  }
+
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+type ModuleResolveFilenameOptions = Parameters<ModuleWithResolve["_resolveFilename"]>[3];


### PR DESCRIPTION
## Summary
- register a runtime path alias shim before loading the API route handlers so compiled code can resolve the `@/` imports
- switch the server entry to use relative handler imports and update the production start script to run the compiled index file

## Testing
- CI=1 pnpm build
- pnpm start

------
https://chatgpt.com/codex/tasks/task_e_68cffff2cdb8832a937472ddc9d89aa9