### PR TITLE
Add interactive route scrubbing and map direction cues

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -26,6 +26,8 @@ interface MapProps {
   bounds?: [[number, number], [number, number]];
   routes: MapRoute[];
   kilometerMarkers?: KilometerMarker[];
+  activeMarker?: { coordinate: LatLng; color?: string };
+  activeProgress?: { polyline: string; color?: string };
 }
 
 function lightenColor(hex: string, amount = 0.5) {
@@ -45,7 +47,14 @@ function lightenColor(hex: string, amount = 0.5) {
     .padStart(2, "0")}${blend(b).toString(16).padStart(2, "0")}`;
 }
 
-export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) {
+export function MapView({
+  center,
+  bounds,
+  routes,
+  kilometerMarkers,
+  activeMarker,
+  activeProgress,
+}: MapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
 
@@ -59,6 +68,34 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
     });
     map.addControl(new maplibregl.NavigationControl());
     mapRef.current = map;
+    const addArrowImage = () => {
+      if (map.hasImage("route-arrow")) {
+        return;
+      }
+      const size = 64;
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        return;
+      }
+      ctx.clearRect(0, 0, size, size);
+      ctx.beginPath();
+      ctx.moveTo(size / 2, size * 0.15);
+      ctx.lineTo(size * 0.82, size * 0.85);
+      ctx.lineTo(size * 0.18, size * 0.85);
+      ctx.closePath();
+      ctx.fillStyle = "#000";
+      ctx.fill();
+      const image = ctx.getImageData(0, 0, size, size);
+      map.addImage("route-arrow", image, { sdf: true });
+    };
+    if (map.isStyleLoaded()) {
+      addArrowImage();
+    } else {
+      map.once("load", addArrowImage);
+    }
     return () => {
       map.remove();
       mapRef.current = null;
@@ -171,6 +208,30 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
             "line-width": ["+", ["get", "width"], 2],
             "line-opacity": 0.9,
             "line-blur": 0.4,
+          },
+        });
+      }
+
+      if (!map.getLayer("routes-direction")) {
+        map.addLayer({
+          id: "routes-direction",
+          type: "symbol",
+          source: sourceId,
+          layout: {
+            "symbol-placement": "line",
+            "symbol-spacing": 80,
+            "icon-image": "route-arrow",
+            "icon-size": 0.6,
+            "icon-allow-overlap": false,
+          },
+          paint: {
+            "icon-color": [
+              "case",
+              ["get", "active"],
+              ["get", "color"],
+              ["get", "inactiveColor"],
+            ],
+            "icon-opacity": ["case", ["get", "active"], 0.9, 0.35],
           },
         });
       }
@@ -292,6 +353,153 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
       map.off("load", onLoad);
     };
   }, [kilometerMarkers]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const sourceId = "route-progress";
+    const layerId = "route-progress";
+
+    const applyProgress = () => {
+      const collection: FeatureCollection<
+        LineString,
+        { color: string }
+      > = activeProgress
+        ? {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {
+                  color: activeProgress.color ?? "#2563eb",
+                },
+                geometry: {
+                  type: "LineString",
+                  coordinates: decodePolyline(activeProgress.polyline).map((point) => [
+                    point.lng,
+                    point.lat,
+                  ]),
+                },
+              },
+            ],
+          }
+        : { type: "FeatureCollection", features: [] };
+
+      const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (existing) {
+        existing.setData(collection);
+      } else {
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: collection,
+        });
+      }
+
+      if (!map.getLayer(layerId)) {
+        const beforeLayer = map.getLayer("routes-direction") ? "routes-direction" : undefined;
+        map.addLayer(
+          {
+            id: layerId,
+            type: "line",
+            source: sourceId,
+            layout: {
+              "line-cap": "round",
+              "line-join": "round",
+            },
+            paint: {
+              "line-color": ["coalesce", ["get", "color"], "#2563eb"],
+              "line-width": 8,
+              "line-opacity": 0.95,
+            },
+          },
+          beforeLayer,
+        );
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      applyProgress();
+      return undefined;
+    }
+
+    const onLoad = () => applyProgress();
+    map.once("load", onLoad);
+    return () => {
+      map.off("load", onLoad);
+    };
+  }, [activeProgress]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const sourceId = "route-progress-point";
+    const layerId = "route-progress-point";
+
+    const applyPoint = () => {
+      const collection: FeatureCollection<Point, { color: string }> = activeMarker
+        ? {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {
+                  color: activeMarker.color ?? "#2563eb",
+                },
+                geometry: {
+                  type: "Point",
+                  coordinates: [activeMarker.coordinate.lng, activeMarker.coordinate.lat],
+                },
+              },
+            ],
+          }
+        : { type: "FeatureCollection", features: [] };
+
+      const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (existing) {
+        existing.setData(collection);
+      } else {
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: collection,
+        });
+      }
+
+      if (!map.getLayer(layerId)) {
+        const beforeLayer = map.getLayer("route-progress")
+          ? "route-progress"
+          : map.getLayer("routes-direction")
+            ? "routes-direction"
+            : undefined;
+        map.addLayer(
+          {
+            id: layerId,
+            type: "circle",
+            source: sourceId,
+            paint: {
+              "circle-radius": 6,
+              "circle-color": ["coalesce", ["get", "color"], "#2563eb"],
+              "circle-stroke-width": 2,
+              "circle-stroke-color": "#ffffff",
+            },
+          },
+          beforeLayer,
+        );
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      applyPoint();
+      return undefined;
+    }
+
+    const onLoad = () => applyPoint();
+    map.once("load", onLoad);
+    return () => {
+      map.off("load", onLoad);
+    };
+  }, [activeMarker]);
 
   return <div ref={containerRef} className="h-full w-full" />;
 }

--- a/components/RouteDetails.tsx
+++ b/components/RouteDetails.tsx
@@ -73,14 +73,16 @@ export function RouteDetails({ route }: RouteDetailsProps) {
                 <span>Del {index + 1}</span>
                 <span>{formatMeters(segment.lengthMeters)}</span>
               </div>
-              <div className="mt-1 text-sm font-medium text-zinc-700">
-                {formatInstruction(segment)}
+              <div className="mt-1 flex flex-wrap items-center gap-2">
+                {segment.streetName && (
+                  <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700">
+                    {segment.streetName}
+                  </span>
+                )}
+                <span className="text-sm font-medium text-zinc-700">
+                  {formatInstruction(segment)}
+                </span>
               </div>
-              {segment.streetName && (
-                <div className="text-[11px] text-zinc-500">
-                  {segment.streetName}
-                </div>
-              )}
               <div className="text-[11px] text-zinc-500">
                 {formatRange(segment.startDistanceMeters, segment.endDistanceMeters)}
                 {" "}• {formatMeters(segment.lengthMeters)}

--- a/components/RouteExplorer.tsx
+++ b/components/RouteExplorer.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useMemo, type ChangeEvent, type CSSProperties } from "react";
+import { ElevationChart } from "@/components/ElevationChart";
+import type { RouteAlternative, RouteKilometerMarker } from "@/types/route";
+
+interface RouteExplorerProps {
+  route?: RouteAlternative;
+  activeDistance: number;
+  activeElevation?: number;
+  onDistanceChange: (distanceMeters: number) => void;
+}
+
+function markerPosition(marker: RouteKilometerMarker, totalDistance: number): number {
+  if (totalDistance <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, (marker.distanceMeters / totalDistance) * 100));
+}
+
+function formatDistanceMeters(meters: number): string {
+  if (!Number.isFinite(meters) || meters < 0) {
+    return "0 m";
+  }
+  if (meters >= 1000) {
+    const km = meters / 1000;
+    const decimals = km >= 10 ? 0 : 1;
+    return `${km.toFixed(decimals)} km`;
+  }
+  return `${Math.round(meters)} m`;
+}
+
+export function RouteExplorer({
+  route,
+  activeDistance,
+  activeElevation,
+  onDistanceChange,
+}: RouteExplorerProps) {
+  const totalDistance = route?.distanceMeters ?? 0;
+  const percentage = totalDistance > 0 ? (activeDistance / totalDistance) * 100 : 0;
+  const clampedPercentage = Number.isFinite(percentage) ? Math.min(Math.max(percentage, 0), 100) : 0;
+
+  const sliderValue = Math.round(clampedPercentage * 10);
+
+  const kilometerMarkers = useMemo(() => route?.kilometerMarkers ?? [], [route?.kilometerMarkers]);
+
+  const sliderStyle = useMemo<CSSProperties>(
+    () => ({
+      background: `linear-gradient(to right, #2563eb 0%, #2563eb ${clampedPercentage}%, #e5e7eb ${clampedPercentage}%, #e5e7eb 100%)`,
+      accentColor: "#2563eb",
+    }),
+    [clampedPercentage],
+  );
+
+  const handleSliderChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!route || totalDistance <= 0) {
+      return;
+    }
+    const value = Number(event.target.value) / 1000;
+    const nextDistance = Math.min(Math.max(value * totalDistance, 0), totalDistance);
+    onDistanceChange(nextDistance);
+  };
+
+  const distanceLabel = formatDistanceMeters(activeDistance);
+  const elevationLabel =
+    activeElevation != null && Number.isFinite(activeElevation)
+      ? `${Math.round(activeElevation)} m`
+      : "–";
+
+  if (!route || totalDistance <= 0) {
+    return (
+      <div className="border-t border-zinc-200 bg-white p-4 text-sm text-zinc-500">
+        Generer en rute for å utforske traséen og høydeprofilen her.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-zinc-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-600">
+        <span>
+          Distanse: <span className="font-medium text-zinc-800">{distanceLabel}</span>
+        </span>
+        <span>
+          Høyde: <span className="font-medium text-zinc-800">{elevationLabel}</span>
+        </span>
+      </div>
+
+      <div className="relative mt-4 pb-6">
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          step={1}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          className="h-2 w-full appearance-none rounded-full"
+          style={sliderStyle}
+        />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-5">
+          {kilometerMarkers.map((marker) => {
+            const position = markerPosition(marker, totalDistance);
+            const tickClass =
+              position <= 1
+                ? "h-3 w-[1px] bg-blue-500"
+                : position >= 99
+                  ? "h-3 w-[1px] -translate-x-full bg-blue-500"
+                  : "h-3 w-[1px] -translate-x-1/2 bg-blue-500";
+            const labelClass =
+              position <= 1
+                ? "mt-1 whitespace-nowrap text-left text-[10px] font-medium text-blue-600"
+                : position >= 99
+                  ? "mt-1 -translate-x-full whitespace-nowrap text-right text-[10px] font-medium text-blue-600"
+                  : "mt-1 -translate-x-1/2 whitespace-nowrap text-center text-[10px] font-medium text-blue-600";
+
+            return (
+              <div
+                key={`${marker.label}-${marker.distanceMeters}`}
+                className="absolute top-0"
+                style={{ left: `${position}%` }}
+              >
+                <div className={tickClass} />
+                <div className={labelClass}>{marker.label}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <ElevationChart
+          profile={route.elevationProfile}
+          activeDistance={activeDistance}
+          onScrub={onDistanceChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lib/elevation/profile.ts
+++ b/lib/elevation/profile.ts
@@ -1,0 +1,53 @@
+import type { RouteAlternative } from "@/types/route";
+
+export function elevationAtDistance(
+  profile: RouteAlternative["elevationProfile"],
+  distanceMeters: number,
+): number | undefined {
+  if (!profile || profile.length === 0) {
+    return undefined;
+  }
+
+  const target = Math.max(0, distanceMeters);
+  const last = profile[profile.length - 1];
+  if (!last) {
+    return undefined;
+  }
+
+  if (target <= profile[0].distance) {
+    return profile[0].elevation;
+  }
+  if (target >= last.distance) {
+    return last.elevation;
+  }
+
+  let index = 1;
+  while (index < profile.length && profile[index].distance < target) {
+    index += 1;
+  }
+
+  const next = profile[index];
+  const prev = profile[index - 1];
+  if (!prev || !next) {
+    return last.elevation;
+  }
+
+  const span = next.distance - prev.distance;
+  const ratio = span <= 0 ? 0 : (target - prev.distance) / span;
+  return prev.elevation + (next.elevation - prev.elevation) * ratio;
+}
+
+export function clampDistance(
+  profile: RouteAlternative["elevationProfile"],
+  distanceMeters: number,
+): number {
+  if (!profile || profile.length === 0) {
+    return Math.max(0, distanceMeters);
+  }
+  const last = profile[profile.length - 1];
+  const max = last?.distance ?? 0;
+  if (!Number.isFinite(max) || max <= 0) {
+    return Math.max(0, distanceMeters);
+  }
+  return Math.min(Math.max(0, distanceMeters), max);
+}


### PR DESCRIPTION
## Summary
- add a route explorer with slider-controlled elevation scrubbing that keeps the chart and map marker in sync
- enhance the map with directional arrows and a highlighted progress segment tied to the scrubber state
- surface street names more prominently in the route description and expose helpers for elevation interpolation

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d019b3c268832ab0e1271b93438d6f