### PR TITLE
Improve running route filtering and elevation data

### DIFF
--- a/app/api/routes/point2point/handler.ts
+++ b/app/api/routes/point2point/handler.ts
@@ -20,6 +20,7 @@ const pointToPointSchema = z.object({
   targetDistanceMeters: z.number().positive(),
   distanceToleranceMeters: z.number().positive().optional(),
   preferElevation: z.enum(["min", "max", "balanced"]).optional(),
+  avoidRevisiting: z.boolean().optional(),
 });
 
 export async function handlePointToPoint(body: unknown): Promise<RouteResponse> {

--- a/app/api/routes/roundtrip/handler.ts
+++ b/app/api/routes/roundtrip/handler.ts
@@ -13,6 +13,7 @@ const roundTripSchema = z.object({
   targetDistanceMeters: z.number().positive(),
   distanceToleranceMeters: z.number().positive().optional(),
   preferElevation: z.enum(["min", "max", "balanced"]).optional(),
+  avoidRevisiting: z.boolean().optional(),
 });
 
 export async function handleRoundTrip(body: unknown): Promise<RouteResponse> {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Controls, ControlsValues, Mode } from "@/components/Controls";
 import { MapView } from "@/components/Map";
 import { RouteSummary } from "@/components/RouteSummary";
 import { RouteDetails } from "@/components/RouteDetails";
-import { ElevationChart } from "@/components/ElevationChart";
+import { RouteExplorer } from "@/components/RouteExplorer";
+import { decodePolyline, encodePolyline } from "@/lib/geo/utils";
+import { cumulativeDistances, interpolatePoint } from "@/lib/geo/distance";
+import { elevationAtDistance } from "@/lib/elevation/profile";
 import type { LatLng, RouteAlternative, RouteResponse } from "@/types/route";
 
 const DEFAULT_VALUES: ControlsValues = {
@@ -14,6 +17,7 @@ const DEFAULT_VALUES: ControlsValues = {
   targetDistanceKm: 10,
   toleranceMeters: 100,
   preferElevation: "balanced",
+  avoidRevisiting: false,
 };
 
 const COLORS = ["#2563eb", "#38bdf8", "#f97316", "#22c55e", "#a855f7"];
@@ -28,8 +32,23 @@ export default function HomePage() {
   const [notes, setNotes] = useState<string[]>([]);
   const [mapCenter, setMapCenter] = useState<LatLng | undefined>();
   const [mapBounds, setMapBounds] = useState<[[number, number], [number, number]] | undefined>();
+  const [activeDistance, setActiveDistance] = useState(0);
 
   const selectedRoute = alternatives[selectedIndex];
+
+  const selectedRoutePath = useMemo(
+    () => (selectedRoute ? decodePolyline(selectedRoute.polyline) : []),
+    [selectedRoute],
+  );
+
+  const selectedRouteDistances = useMemo(
+    () => (selectedRoutePath.length > 0 ? cumulativeDistances(selectedRoutePath) : []),
+    [selectedRoutePath],
+  );
+
+  useEffect(() => {
+    setActiveDistance(0);
+  }, [selectedRoute?.polyline]);
 
   const mapRoutes = useMemo(
     () =>
@@ -43,6 +62,76 @@ export default function HomePage() {
     [alternatives, selectedIndex],
   );
 
+  const totalDistance = selectedRoute?.distanceMeters ?? 0;
+  const clampedDistance = useMemo(() => {
+    if (!selectedRoute || totalDistance <= 0) {
+      return 0;
+    }
+    return Math.min(Math.max(activeDistance, 0), totalDistance);
+  }, [activeDistance, selectedRoute, totalDistance]);
+
+  const activeCoordinate = useMemo(() => {
+    if (!selectedRoute || selectedRoutePath.length === 0 || selectedRouteDistances.length === 0) {
+      return undefined;
+    }
+    return interpolatePoint(selectedRoutePath, selectedRouteDistances, clampedDistance);
+  }, [clampedDistance, selectedRoute, selectedRouteDistances, selectedRoutePath]);
+
+  const activeElevation = useMemo(() => {
+    if (!selectedRoute?.elevationProfile || selectedRoute.elevationProfile.length === 0) {
+      return undefined;
+    }
+    return elevationAtDistance(selectedRoute.elevationProfile, clampedDistance);
+  }, [clampedDistance, selectedRoute]);
+
+  const activeProgress = useMemo(() => {
+    if (!selectedRoute || selectedRoutePath.length === 0 || selectedRouteDistances.length === 0) {
+      return undefined;
+    }
+    if (clampedDistance <= 0) {
+      return undefined;
+    }
+
+    const coords: LatLng[] = [];
+    for (let i = 0; i < selectedRoutePath.length; i += 1) {
+      const distance = selectedRouteDistances[i] ?? 0;
+      const point = selectedRoutePath[i];
+      if (coords.length === 0) {
+        coords.push(point);
+      }
+      if (distance < clampedDistance) {
+        if (i > 0) {
+          coords.push(point);
+        }
+        continue;
+      }
+
+      if (distance === clampedDistance) {
+        coords.push(point);
+      } else if (i > 0) {
+        const prevDistance = selectedRouteDistances[i - 1] ?? 0;
+        const prevPoint = selectedRoutePath[i - 1];
+        const span = distance - prevDistance;
+        const ratio = span <= 0 ? 0 : (clampedDistance - prevDistance) / span;
+        coords.push({
+          lat: prevPoint.lat + (point.lat - prevPoint.lat) * ratio,
+          lng: prevPoint.lng + (point.lng - prevPoint.lng) * ratio,
+        });
+      }
+      break;
+    }
+
+    if (coords.length < 2) {
+      return undefined;
+    }
+
+    const activeRoute = mapRoutes[selectedIndex];
+    return {
+      polyline: encodePolyline(coords),
+      color: activeRoute?.color,
+    };
+  }, [clampedDistance, mapRoutes, selectedIndex, selectedRoute, selectedRouteDistances, selectedRoutePath]);
+
   const requestBody = () => {
     const targetDistanceMeters = Math.round(values.targetDistanceKm * 1000);
     const basePayload = {
@@ -50,6 +139,7 @@ export default function HomePage() {
       targetDistanceMeters,
       distanceToleranceMeters: values.toleranceMeters,
       preferElevation: values.preferElevation,
+      avoidRevisiting: values.avoidRevisiting,
     };
     if (mode === "roundtrip") {
       return basePayload;
@@ -153,7 +243,6 @@ export default function HomePage() {
             onSelect={setSelectedIndex}
           />
           <RouteDetails route={selectedRoute} />
-          <ElevationChart profile={selectedRoute?.elevationProfile} />
         </aside>
 
         <section className="flex-1 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow">
@@ -163,8 +252,23 @@ export default function HomePage() {
               bounds={mapBounds}
               routes={mapRoutes}
               kilometerMarkers={selectedRoute?.kilometerMarkers}
+              activeMarker={
+                activeCoordinate
+                  ? {
+                      coordinate: activeCoordinate,
+                      color: mapRoutes[selectedIndex]?.color,
+                    }
+                  : undefined
+              }
+              activeProgress={activeProgress}
             />
           </div>
+          <RouteExplorer
+            route={selectedRoute}
+            activeDistance={clampedDistance}
+            activeElevation={activeElevation}
+            onDistanceChange={setActiveDistance}
+          />
         </section>
       </div>
     </main>

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -10,6 +10,7 @@ export interface ControlsValues {
   targetDistanceKm: number;
   toleranceMeters: number;
   preferElevation: "min" | "balanced" | "max";
+  avoidRevisiting: boolean;
 }
 
 interface ControlsProps {
@@ -159,6 +160,18 @@ export function Controls({
           ))}
         </div>
       </div>
+
+      <label className="flex items-center gap-2 text-xs font-semibold text-zinc-600">
+        <input
+          type="checkbox"
+          checked={values.avoidRevisiting}
+          onChange={(event) => onChange({ avoidRevisiting: event.target.checked })}
+          className="h-4 w-4 rounded border border-zinc-300 text-blue-600 focus:ring-blue-500"
+        />
+        <span className="font-medium normal-case text-zinc-700">
+          Unngå å løpe samme strekning to ganger
+        </span>
+      </label>
 
       <button
         type="button"

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -26,6 +26,8 @@ interface MapProps {
   bounds?: [[number, number], [number, number]];
   routes: MapRoute[];
   kilometerMarkers?: KilometerMarker[];
+  activeMarker?: { coordinate: LatLng; color?: string };
+  activeProgress?: { polyline: string; color?: string };
 }
 
 function lightenColor(hex: string, amount = 0.5) {
@@ -45,7 +47,14 @@ function lightenColor(hex: string, amount = 0.5) {
     .padStart(2, "0")}${blend(b).toString(16).padStart(2, "0")}`;
 }
 
-export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) {
+export function MapView({
+  center,
+  bounds,
+  routes,
+  kilometerMarkers,
+  activeMarker,
+  activeProgress,
+}: MapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
 
@@ -59,6 +68,34 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
     });
     map.addControl(new maplibregl.NavigationControl());
     mapRef.current = map;
+    const addArrowImage = () => {
+      if (map.hasImage("route-arrow")) {
+        return;
+      }
+      const size = 64;
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        return;
+      }
+      ctx.clearRect(0, 0, size, size);
+      ctx.beginPath();
+      ctx.moveTo(size / 2, size * 0.15);
+      ctx.lineTo(size * 0.82, size * 0.85);
+      ctx.lineTo(size * 0.18, size * 0.85);
+      ctx.closePath();
+      ctx.fillStyle = "#000";
+      ctx.fill();
+      const image = ctx.getImageData(0, 0, size, size);
+      map.addImage("route-arrow", image, { sdf: true });
+    };
+    if (map.isStyleLoaded()) {
+      addArrowImage();
+    } else {
+      map.once("load", addArrowImage);
+    }
     return () => {
       map.remove();
       mapRef.current = null;
@@ -171,6 +208,30 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
             "line-width": ["+", ["get", "width"], 2],
             "line-opacity": 0.9,
             "line-blur": 0.4,
+          },
+        });
+      }
+
+      if (!map.getLayer("routes-direction")) {
+        map.addLayer({
+          id: "routes-direction",
+          type: "symbol",
+          source: sourceId,
+          layout: {
+            "symbol-placement": "line",
+            "symbol-spacing": 80,
+            "icon-image": "route-arrow",
+            "icon-size": 0.6,
+            "icon-allow-overlap": false,
+          },
+          paint: {
+            "icon-color": [
+              "case",
+              ["get", "active"],
+              ["get", "color"],
+              ["get", "inactiveColor"],
+            ],
+            "icon-opacity": ["case", ["get", "active"], 0.9, 0.35],
           },
         });
       }
@@ -292,6 +353,153 @@ export function MapView({ center, bounds, routes, kilometerMarkers }: MapProps) 
       map.off("load", onLoad);
     };
   }, [kilometerMarkers]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const sourceId = "route-progress";
+    const layerId = "route-progress";
+
+    const applyProgress = () => {
+      const collection: FeatureCollection<
+        LineString,
+        { color: string }
+      > = activeProgress
+        ? {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {
+                  color: activeProgress.color ?? "#2563eb",
+                },
+                geometry: {
+                  type: "LineString",
+                  coordinates: decodePolyline(activeProgress.polyline).map((point) => [
+                    point.lng,
+                    point.lat,
+                  ]),
+                },
+              },
+            ],
+          }
+        : { type: "FeatureCollection", features: [] };
+
+      const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (existing) {
+        existing.setData(collection);
+      } else {
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: collection,
+        });
+      }
+
+      if (!map.getLayer(layerId)) {
+        const beforeLayer = map.getLayer("routes-direction") ? "routes-direction" : undefined;
+        map.addLayer(
+          {
+            id: layerId,
+            type: "line",
+            source: sourceId,
+            layout: {
+              "line-cap": "round",
+              "line-join": "round",
+            },
+            paint: {
+              "line-color": ["coalesce", ["get", "color"], "#2563eb"],
+              "line-width": 8,
+              "line-opacity": 0.95,
+            },
+          },
+          beforeLayer,
+        );
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      applyProgress();
+      return undefined;
+    }
+
+    const onLoad = () => applyProgress();
+    map.once("load", onLoad);
+    return () => {
+      map.off("load", onLoad);
+    };
+  }, [activeProgress]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const sourceId = "route-progress-point";
+    const layerId = "route-progress-point";
+
+    const applyPoint = () => {
+      const collection: FeatureCollection<Point, { color: string }> = activeMarker
+        ? {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {
+                  color: activeMarker.color ?? "#2563eb",
+                },
+                geometry: {
+                  type: "Point",
+                  coordinates: [activeMarker.coordinate.lng, activeMarker.coordinate.lat],
+                },
+              },
+            ],
+          }
+        : { type: "FeatureCollection", features: [] };
+
+      const existing = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (existing) {
+        existing.setData(collection);
+      } else {
+        map.addSource(sourceId, {
+          type: "geojson",
+          data: collection,
+        });
+      }
+
+      if (!map.getLayer(layerId)) {
+        const beforeLayer = map.getLayer("route-progress")
+          ? "route-progress"
+          : map.getLayer("routes-direction")
+            ? "routes-direction"
+            : undefined;
+        map.addLayer(
+          {
+            id: layerId,
+            type: "circle",
+            source: sourceId,
+            paint: {
+              "circle-radius": 6,
+              "circle-color": ["coalesce", ["get", "color"], "#2563eb"],
+              "circle-stroke-width": 2,
+              "circle-stroke-color": "#ffffff",
+            },
+          },
+          beforeLayer,
+        );
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      applyPoint();
+      return undefined;
+    }
+
+    const onLoad = () => applyPoint();
+    map.once("load", onLoad);
+    return () => {
+      map.off("load", onLoad);
+    };
+  }, [activeMarker]);
 
   return <div ref={containerRef} className="h-full w-full" />;
 }

--- a/components/RouteDetails.tsx
+++ b/components/RouteDetails.tsx
@@ -73,14 +73,16 @@ export function RouteDetails({ route }: RouteDetailsProps) {
                 <span>Del {index + 1}</span>
                 <span>{formatMeters(segment.lengthMeters)}</span>
               </div>
-              <div className="mt-1 text-sm font-medium text-zinc-700">
-                {formatInstruction(segment)}
+              <div className="mt-1 flex flex-wrap items-center gap-2">
+                {segment.streetName && (
+                  <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700">
+                    {segment.streetName}
+                  </span>
+                )}
+                <span className="text-sm font-medium text-zinc-700">
+                  {formatInstruction(segment)}
+                </span>
               </div>
-              {segment.streetName && (
-                <div className="text-[11px] text-zinc-500">
-                  {segment.streetName}
-                </div>
-              )}
               <div className="text-[11px] text-zinc-500">
                 {formatRange(segment.startDistanceMeters, segment.endDistanceMeters)}
                 {" "}• {formatMeters(segment.lengthMeters)}

--- a/components/RouteExplorer.tsx
+++ b/components/RouteExplorer.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useMemo, type ChangeEvent, type CSSProperties } from "react";
+import { ElevationChart } from "@/components/ElevationChart";
+import type { RouteAlternative, RouteKilometerMarker } from "@/types/route";
+
+interface RouteExplorerProps {
+  route?: RouteAlternative;
+  activeDistance: number;
+  activeElevation?: number;
+  onDistanceChange: (distanceMeters: number) => void;
+}
+
+function markerPosition(marker: RouteKilometerMarker, totalDistance: number): number {
+  if (totalDistance <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, (marker.distanceMeters / totalDistance) * 100));
+}
+
+function formatDistanceMeters(meters: number): string {
+  if (!Number.isFinite(meters) || meters < 0) {
+    return "0 m";
+  }
+  if (meters >= 1000) {
+    const km = meters / 1000;
+    const decimals = km >= 10 ? 0 : 1;
+    return `${km.toFixed(decimals)} km`;
+  }
+  return `${Math.round(meters)} m`;
+}
+
+export function RouteExplorer({
+  route,
+  activeDistance,
+  activeElevation,
+  onDistanceChange,
+}: RouteExplorerProps) {
+  const totalDistance = route?.distanceMeters ?? 0;
+  const percentage = totalDistance > 0 ? (activeDistance / totalDistance) * 100 : 0;
+  const clampedPercentage = Number.isFinite(percentage) ? Math.min(Math.max(percentage, 0), 100) : 0;
+
+  const sliderValue = Math.round(clampedPercentage * 10);
+
+  const kilometerMarkers = useMemo(() => route?.kilometerMarkers ?? [], [route?.kilometerMarkers]);
+
+  const sliderStyle = useMemo<CSSProperties>(
+    () => ({
+      background: `linear-gradient(to right, #2563eb 0%, #2563eb ${clampedPercentage}%, #e5e7eb ${clampedPercentage}%, #e5e7eb 100%)`,
+      accentColor: "#2563eb",
+    }),
+    [clampedPercentage],
+  );
+
+  const handleSliderChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!route || totalDistance <= 0) {
+      return;
+    }
+    const value = Number(event.target.value) / 1000;
+    const nextDistance = Math.min(Math.max(value * totalDistance, 0), totalDistance);
+    onDistanceChange(nextDistance);
+  };
+
+  const distanceLabel = formatDistanceMeters(activeDistance);
+  const elevationLabel =
+    activeElevation != null && Number.isFinite(activeElevation)
+      ? `${Math.round(activeElevation)} m`
+      : "–";
+
+  if (!route || totalDistance <= 0) {
+    return (
+      <div className="border-t border-zinc-200 bg-white p-4 text-sm text-zinc-500">
+        Generer en rute for å utforske traséen og høydeprofilen her.
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-zinc-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-600">
+        <span>
+          Distanse: <span className="font-medium text-zinc-800">{distanceLabel}</span>
+        </span>
+        <span>
+          Høyde: <span className="font-medium text-zinc-800">{elevationLabel}</span>
+        </span>
+      </div>
+
+      <div className="relative mt-4 pb-6">
+        <input
+          type="range"
+          min={0}
+          max={1000}
+          step={1}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          className="h-2 w-full appearance-none rounded-full"
+          style={sliderStyle}
+        />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-5">
+          {kilometerMarkers.map((marker) => {
+            const position = markerPosition(marker, totalDistance);
+            const tickClass =
+              position <= 1
+                ? "h-3 w-[1px] bg-blue-500"
+                : position >= 99
+                  ? "h-3 w-[1px] -translate-x-full bg-blue-500"
+                  : "h-3 w-[1px] -translate-x-1/2 bg-blue-500";
+            const labelClass =
+              position <= 1
+                ? "mt-1 whitespace-nowrap text-left text-[10px] font-medium text-blue-600"
+                : position >= 99
+                  ? "mt-1 -translate-x-full whitespace-nowrap text-right text-[10px] font-medium text-blue-600"
+                  : "mt-1 -translate-x-1/2 whitespace-nowrap text-center text-[10px] font-medium text-blue-600";
+
+            return (
+              <div
+                key={`${marker.label}-${marker.distanceMeters}`}
+                className="absolute top-0"
+                style={{ left: `${position}%` }}
+              >
+                <div className={tickClass} />
+                <div className={labelClass}>{marker.label}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <ElevationChart
+          profile={route.elevationProfile}
+          activeDistance={activeDistance}
+          onScrub={onDistanceChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lib/elevation/mapboxTerrain.ts
+++ b/lib/elevation/mapboxTerrain.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import pLimit from "p-limit";
 import { decodePolyline } from "@/lib/geo/utils";
-import { interpolateAlongPath } from "@/lib/geo/distance";
+import { haversineDistance, interpolateAlongPath } from "@/lib/geo/distance";
 import type { ElevationProfilePoint, ElevationService, ElevationTotals } from "./index";
 import { computeTotals } from "./index";
 
@@ -46,16 +46,7 @@ export class MapboxTerrainElevationService implements ElevationService {
     return samples.map((point, index) => {
       if (index > 0) {
         const prev = samples[index - 1];
-        const dLat = point.lat - prev.lat;
-        const dLng = point.lng - prev.lng;
-        const meanLat = ((point.lat + prev.lat) / 2) * (Math.PI / 180);
-        const kmPerDegreeLat = 111132.954 - 559.822 * Math.cos(2 * meanLat) + 1.175 * Math.cos(4 * meanLat);
-        const kmPerDegreeLng = 111132.954 * Math.cos(meanLat);
-        const delta = Math.sqrt(
-          (dLat * kmPerDegreeLat) ** 2 +
-            (dLng * kmPerDegreeLng) ** 2,
-        );
-        distance += delta * 1000;
+        distance += haversineDistance(prev, point);
       }
       return { d: distance, z: elevations[index] };
     });

--- a/lib/elevation/profile.ts
+++ b/lib/elevation/profile.ts
@@ -1,0 +1,53 @@
+import type { RouteAlternative } from "@/types/route";
+
+export function elevationAtDistance(
+  profile: RouteAlternative["elevationProfile"],
+  distanceMeters: number,
+): number | undefined {
+  if (!profile || profile.length === 0) {
+    return undefined;
+  }
+
+  const target = Math.max(0, distanceMeters);
+  const last = profile[profile.length - 1];
+  if (!last) {
+    return undefined;
+  }
+
+  if (target <= profile[0].distance) {
+    return profile[0].elevation;
+  }
+  if (target >= last.distance) {
+    return last.elevation;
+  }
+
+  let index = 1;
+  while (index < profile.length && profile[index].distance < target) {
+    index += 1;
+  }
+
+  const next = profile[index];
+  const prev = profile[index - 1];
+  if (!prev || !next) {
+    return last.elevation;
+  }
+
+  const span = next.distance - prev.distance;
+  const ratio = span <= 0 ? 0 : (target - prev.distance) / span;
+  return prev.elevation + (next.elevation - prev.elevation) * ratio;
+}
+
+export function clampDistance(
+  profile: RouteAlternative["elevationProfile"],
+  distanceMeters: number,
+): number {
+  if (!profile || profile.length === 0) {
+    return Math.max(0, distanceMeters);
+  }
+  const last = profile[profile.length - 1];
+  const max = last?.distance ?? 0;
+  if (!Number.isFinite(max) || max <= 0) {
+    return Math.max(0, distanceMeters);
+  }
+  return Math.min(Math.max(0, distanceMeters), max);
+}

--- a/lib/routing/index.ts
+++ b/lib/routing/index.ts
@@ -89,6 +89,7 @@ export async function planRoundTrip(
   const { routing, geocoder, elevation } = deps;
   const tolerance = request.distanceToleranceMeters ?? DEFAULT_TOLERANCE;
   const preferElevation = request.preferElevation ?? "balanced";
+  const avoidRevisiting = request.avoidRevisiting ?? false;
   const start = await resolvePoint(request.start, request.startAddress, geocoder);
 
   const target = request.targetDistanceMeters;
@@ -135,9 +136,10 @@ export async function planRoundTrip(
   }
 
   const unique = dedupeRoutes(enriched);
-  const sorted = sortAlternatives(unique, preferElevation, target);
+  const filtered = applyRevisitPreference(unique, avoidRevisiting, notes);
+  const sorted = sortAlternatives(filtered, preferElevation, target);
 
-  const top = sorted.slice(0, 5);
+  const top = sorted.slice(0, 3);
   const focusPoints = top.flatMap((alt) => decodePolyline(alt.polyline));
   const center = centroid(focusPoints);
   const bounds = computeBounds(focusPoints);
@@ -156,6 +158,7 @@ export async function planPointToPoint(
   const { routing, geocoder, elevation } = deps;
   const tolerance = request.distanceToleranceMeters ?? DEFAULT_TOLERANCE;
   const preferElevation = request.preferElevation ?? "balanced";
+  const avoidRevisiting = request.avoidRevisiting ?? false;
   const start = await resolvePoint(request.start, request.startAddress, geocoder);
   const end = await resolvePoint(request.end, request.endAddress, geocoder);
 
@@ -169,6 +172,7 @@ export async function planPointToPoint(
   const baselineDistance = baseline.distanceMeters;
   const target = request.targetDistanceMeters;
   const delta = target - baselineDistance;
+  const notes: string[] = [];
 
   const candidates: RouteCandidate[] = baselineRoutes.map((route, index) => ({
     route,
@@ -188,14 +192,15 @@ export async function planPointToPoint(
 
   const enriched = await enrichCandidates(candidates, elevation);
   const unique = dedupeRoutes(enriched);
-  const sorted = sortAlternatives(unique, preferElevation, target);
-  const top = sorted.slice(0, 5);
+  const filtered = applyRevisitPreference(unique, avoidRevisiting, notes);
+  const sorted = sortAlternatives(filtered, preferElevation, target);
+  const top = sorted.slice(0, 3);
   const focusPoints = top.flatMap((alt) => decodePolyline(alt.polyline));
   return {
     alternatives: top,
     center: centroid(focusPoints),
     bounds: computeBounds(focusPoints),
-    notes: [],
+    notes,
   };
 }
 
@@ -268,6 +273,7 @@ async function enrichCandidates(
     const signature = hashPath(candidate.route.coordinates);
     if (seen.has(signature)) continue;
     seen.add(signature);
+    const revisitFraction = computeRevisitFraction(candidate.route.coordinates);
     const profile = await elevation.getProfile(candidate.route.polyline);
     const totals = elevation.getTotals(profile);
     const annotations = buildRouteAnnotations(
@@ -288,6 +294,7 @@ async function enrichCandidates(
       kilometerMarkers: annotations.markers,
       segments: annotations.segments,
       providerMeta: { kind: candidate.kind, label: candidate.label },
+      revisitFraction,
     };
     enriched.push(alternative);
   }
@@ -303,6 +310,90 @@ function dedupeRoutes(alternatives: RouteAlternative[]): RouteAlternative[] {
     }
   });
   return Array.from(unique.values());
+}
+
+const REVISIT_THRESHOLD = 0.05;
+
+function applyRevisitPreference(
+  alternatives: RouteAlternative[],
+  avoidRevisiting: boolean,
+  notes?: string[],
+): RouteAlternative[] {
+  if (!avoidRevisiting) {
+    return alternatives;
+  }
+
+  const filtered = alternatives.filter((alt) =>
+    (alt.revisitFraction ?? 0) <= REVISIT_THRESHOLD,
+  );
+
+  if (filtered.length === 0) {
+    notes?.push(
+      "Fant ingen helt unike ruter, viser beste alternativer med noe overlapp.",
+    );
+    return alternatives;
+  }
+
+  if (filtered.length < alternatives.length) {
+    notes?.push(
+      `Filtrerte bort ${alternatives.length - filtered.length} ruter som brukte samme strekning to ganger.`,
+    );
+  }
+
+  return filtered;
+}
+
+function computeRevisitFraction(path: { lat: number; lng: number }[]): number {
+  if (path.length < 2) {
+    return 0;
+  }
+
+  let total = 0;
+  const segmentUsage = new Map<string, { count: number; length: number }>();
+
+  for (let i = 1; i < path.length; i += 1) {
+    const start = path[i - 1];
+    const end = path[i];
+    const length = haversineDistance(start, end);
+    total += length;
+    if (length <= 0) {
+      continue;
+    }
+    const key = segmentKey(start, end);
+    const entry = segmentUsage.get(key);
+    if (entry) {
+      entry.count += 1;
+      entry.length += length;
+    } else {
+      segmentUsage.set(key, { count: 1, length });
+    }
+  }
+
+  if (total <= 0) {
+    return 0;
+  }
+
+  let repeated = 0;
+  for (const segment of segmentUsage.values()) {
+    if (segment.count > 1) {
+      repeated += segment.length;
+    }
+  }
+
+  return repeated / total;
+}
+
+function segmentKey(a: { lat: number; lng: number }, b: { lat: number; lng: number }): string {
+  const precision = 1e5;
+  const ax = Math.round(a.lat * precision);
+  const ay = Math.round(a.lng * precision);
+  const bx = Math.round(b.lat * precision);
+  const by = Math.round(b.lng * precision);
+
+  if (ax < bx || (ax === bx && ay <= by)) {
+    return `${ax},${ay}|${bx},${by}`;
+  }
+  return `${bx},${by}|${ax},${ay}`;
 }
 
 function buildRouteAnnotations(

--- a/lib/routing/providers/ors.ts
+++ b/lib/routing/providers/ors.ts
@@ -45,23 +45,38 @@ export class OrsRoutingProvider implements RoutingProvider {
     const body: {
       coordinates: [number, number][];
       options?: {
-        alternative_routes: {
+        alternative_routes?: {
           target_count: number;
           share_factor: number;
           weight_factor: number;
         };
+        avoid_features?: string[];
       };
     } = {
       coordinates: coordinates.map((c) => [c.lng, c.lat]),
     };
-    if (options?.alternatives) {
-      body.options = {
-        alternative_routes: {
-          target_count: options.alternatives,
-          share_factor: 0.6,
-          weight_factor: 3,
-        },
+
+    const optionsPayload: {
+      alternative_routes?: {
+        target_count: number;
+        share_factor: number;
+        weight_factor: number;
       };
+      avoid_features?: string[];
+    } = {
+      avoid_features: ["highways", "tollways"],
+    };
+
+    if (options?.alternatives) {
+      optionsPayload.alternative_routes = {
+        target_count: options.alternatives,
+        share_factor: 0.6,
+        weight_factor: 3,
+      };
+    }
+
+    if (optionsPayload.alternative_routes || optionsPayload.avoid_features) {
+      body.options = optionsPayload;
     }
 
     const response = await axios.post(
@@ -91,6 +106,9 @@ export class OrsRoutingProvider implements RoutingProvider {
           length: options.length,
           points: 3,
           seed: options.seed ?? Math.floor(Math.random() * 10000),
+        },
+        options: {
+          avoid_features: ["highways", "tollways"],
         },
       },
       {

--- a/lib/routing/providers/osrm.ts
+++ b/lib/routing/providers/osrm.ts
@@ -85,6 +85,9 @@ export class OsrmRoutingProvider implements RoutingProvider {
     url.searchParams.set("geometries", "polyline");
     url.searchParams.set("steps", "true");
     url.searchParams.set("annotations", "distance,duration");
+    if (this.profile === "foot") {
+      url.searchParams.set("exclude", "motorway");
+    }
 
     const response = await axios.get(url.toString(), {
       headers: {

--- a/types/route.ts
+++ b/types/route.ts
@@ -4,6 +4,7 @@ export interface RouteRequestBase {
   preferElevation?: "min" | "max" | "balanced";
   targetDistanceMeters: number;
   distanceToleranceMeters?: number;
+  avoidRevisiting?: boolean;
 }
 
 export interface RoundTripRequest extends RouteRequestBase {
@@ -28,6 +29,7 @@ export interface RouteAlternative {
   kilometerMarkers?: RouteKilometerMarker[];
   segments?: RouteSegment[];
   providerMeta?: unknown;
+  revisitFraction?: number;
 }
 
 export interface RouteResponse {


### PR DESCRIPTION
## Summary
- add a UI toggle and backend filtering so we can request unique routes that avoid reusing the same stretch twice
- fix elevation sampling distance calculations so the chart and scrubber reflect the full course length
- filter out motorway-only roads from routing providers and limit the response to the top three alternatives

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d019b3c268832ab0e1271b93438d6f